### PR TITLE
audio: hal: Use default sample rate from pulseaudio settings

### DIFF
--- a/hal/audio_hw.c
+++ b/hal/audio_hw.c
@@ -3033,6 +3033,8 @@ static int adev_open_output_stream(struct audio_hw_device *dev,
                 out->format = audio_format_from_pcm_format(out->config.format);
             }
         }
+        if (config->sample_rate != 0)
+            out->config.rate = config->sample_rate;
         out->sample_rate = out->config.rate;
     }
     ALOGV("%s: Usecase(%s) config->format %#x  out->config.format %#x\n",


### PR DESCRIPTION
Sample rate is always 48 kHz. Playing 44.1 kHz stream is causing crackling sound as resampler is too slow. Fix ignoring pulseaudio settings and use default sample rate 44,1 kHz if it's not specified through /etc/pulse/daemon.conf. You can override it changing 'default-sample-rate' parameter. You can override sample rate through /etc/pulse/touch.pa as well using 'rate', 'sink_rate' or source_rate' parameter when loading module-droid-card-24.